### PR TITLE
Feat: 2시 이전/이후 주문 시 배송 메시지 추가 , 홈 화면에 회원/비회원 주문하기 버튼 추가

### DIFF
--- a/src/main/java/programmers/coffee/domain/order/controller/OrderController.java
+++ b/src/main/java/programmers/coffee/domain/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package programmers.coffee.domain.order.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -28,6 +29,19 @@ public class OrderController {
     public String orderPage(Model model) {
         List<Item> items = itemRepository.findAll();
         model.addAttribute("items", items);
+
+        LocalTime now = LocalTime.now();
+        String deliveryNotice;
+
+        // 오후 2시 기준 분기
+        if (now.isBefore(LocalTime.of(14, 0))) {
+            deliveryNotice = "당일 배송을 시작합니다.";
+        } else {
+            deliveryNotice = "오후 2시 이후 주문은 다음날 배송을 시작합니다";
+        }
+
+        // 모델에 추가
+        model.addAttribute("deliveryNotice", deliveryNotice);
         return "order/orderForm";
     }
 
@@ -85,6 +99,19 @@ public class OrderController {
         List<Item> items = itemRepository.findAll();
         model.addAttribute("items", items);
         model.addAttribute("user", userDetails.getUser());
+
+        LocalTime now = LocalTime.now();
+        String deliveryNotice;
+
+        // 오후 2시 기준 분기
+        if (now.isBefore(LocalTime.of(14, 0))) {
+            deliveryNotice = "당일 배송을 시작합니다.";
+        } else {
+            deliveryNotice = "오후 2시 이후 주문은 다음날 배송을 시작합니다";
+        }
+
+        // 모델에 추가
+        model.addAttribute("deliveryNotice", deliveryNotice);
         return "order/orderMemberForm";
     }
 

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -54,6 +54,10 @@
                     <div class="d-flex justify-content-between mt-3">
                         <a th:href="@{/users/signup}" class="btn btn-outline-secondary w-48">회원가입</a>
                         <a th:href="@{/items}" class="btn btn-outline-primary w-48">메뉴 보기</a>
+                        <a th:href="@{/orders}" class="btn btn-outline-success w-48">주문 하기</a>
+
+
+                        </a>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/order/orderForm.html
+++ b/src/main/resources/templates/order/orderForm.html
@@ -40,6 +40,7 @@
       <input name="email" type="email" placeholder="이메일">
       <input name="address" type="text" placeholder="주소">
       <input name="zipCode" type="text" placeholder="우편번호">
+      <p th:text="${deliveryNotice}"></p>
       <button type="submit">주문하기</button>
   </div>
 </div>

--- a/src/main/resources/templates/order/orderMemberForm.html
+++ b/src/main/resources/templates/order/orderMemberForm.html
@@ -38,6 +38,8 @@
     <h3>주문 정보 입력</h3>
       <input name="address" type="text" placeholder="주소">
       <input name="zipCode" type="text" placeholder="우편번호">
+
+      <p th:text="${deliveryNotice}"></p>
       <button type="submit">주문하기</button>
   </div>
 </div>

--- a/src/main/resources/templates/user/userHome.html
+++ b/src/main/resources/templates/user/userHome.html
@@ -36,6 +36,7 @@
         <p>주문을 하시거나 주문 내역을 조회해보세요.</p>
         <div class="d-flex justify-content-center gap-3 mt-4">
             <a th:href="@{/menus}" class="btn btn-primary">메뉴 보기</a>
+            <a th:href="@{/orders/member}" class="btn btn-outline-success w-48">주문 하기</a>
             <a th:href="@{/orders/my/history}" class="btn btn-secondary">주문 내역</a>
         </div>
     </main>


### PR DESCRIPTION
## 📌 과제 설명
- 비회원 주문화면 및 회원 주문화면에서 "당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다." 메시지를 동적으로 출력하는 기능을 추가했습니다.

- LocalDateTime.now()를 이용하여 현재 시간을 체크하고, 14시(2시) 이후일 경우 문구를 다르게 보여줍니다.
- 
-회원 주문화면과 비회원 주문화면에 "주문하기" 버튼을 추가했습니다.

-회원은 로그인 후 /user 화면에, 비회원은 초기 홈화면 /에 각각 주문하기 버튼을 배치했습니다.

-주문 버튼을 테두리 초록색(btn-outline-success) 스타일로 통일했습니다.

## 🙊 요구 사항과 구현 내용
- 주문 화면(비회원/회원 모두)에서 주문 정보 입력 폼 하단에 메시지를 표시합니다.
- LocalDateTime.now()를 기준으로
  - 14시 이전 주문 시: "당일 배송을 시작합니다."
  - 14시 이후 주문 시: "다음날 배송을 시작합니다."
- Thymeleaf에서 서버로부터 전달받은 배송 메시지를 출력합니다.
- 주문 화면을 새로고침할 때마다 현재 시간 기준으로 메시지가 반영되도록 처리했습니다.

- 버튼 배치는 기존 버튼들(회원가입, 메뉴보기 등)과 동일한 스타일을 유지했습니다.

## ✅ 피드백 반영사항


## ✅ PR 포인트 & 궁금한 점
