### PR TITLE
Chore : 메뉴 보기 시 상품 설명, 상품 재고 삭제 및 주문 시 오류 문구 수정

### DIFF
--- a/src/main/java/programmers/coffee/domain/item/domain/Item.java
+++ b/src/main/java/programmers/coffee/domain/item/domain/Item.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 @Builder
 @Data
+
 public class Item {
     private Long itemId;
     private String itemName;
@@ -13,7 +14,6 @@ public class Item {
     private String imageUrl;
 
     public Item() {
-
     }
 
     @Builder

--- a/src/main/java/programmers/coffee/global/exception/OutOfStockException.java
+++ b/src/main/java/programmers/coffee/global/exception/OutOfStockException.java
@@ -9,7 +9,7 @@ public class OutOfStockException extends RuntimeException {
     private final List<ItemResponseDto> items; // <<< 추가!
 
     public OutOfStockException(Long itemId, List<ItemResponseDto> items) {
-        super("[" + itemId + "] 재고 부족");
+        super("재고가 부족합니다. 다른 상품 선택해주세요!");
         this.itemId = itemId;
         this.items = items;
     }

--- a/src/main/resources/templates/item/list.html
+++ b/src/main/resources/templates/item/list.html
@@ -89,9 +89,7 @@
     <div th:each="item : ${items}" class="menu-card">
         <img th:src="${item.imageUrl}" alt="상품 이미지"/>
         <h3 th:text="${item.itemName}">커피 이름</h3>
-        <p th:text="${item.description}">설명</p>
         <p th:text="'가격: ' + ${item.price} + '원'"></p>
-        <p th:text="'재고: ' + ${item.stockCount} + '개'"></p>
         <a th:href="@{|/items/${item.itemId}|}">상세 보기</a>
     </div>
 </div>


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
메뉴 페이지에서 상품 등록 이후 상품에 등록 정보가 전부 담겨있어 수정하였습니다.
초과 주문 시 오류 문구 수정하였습니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
'item/list.html' : 기존 설명과 재고를 나타내는부분의 코드 삭제
'global/exception/OrderAdvice' : 재고 보다 많은 주문 수량 주문 시 오류 문구 수정
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
