### PR TITLE
fix: 주문 생성 시 이름이 email 컬럼에 저장되는 버그 수정

### DIFF
--- a/src/main/java/programmers/coffee/domain/order/controller/OrderController.java
+++ b/src/main/java/programmers/coffee/domain/order/controller/OrderController.java
@@ -124,7 +124,7 @@ public class OrderController {
     @PostMapping("/orders/member")
     public String createTeamOrder(@AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest request) {
         Long userId = userDetails.getUser().getId();
-        String email = userDetails.getUsername();
+        String email = userDetails.getEmail();
         String address = request.getParameter("address");
         String zipCode = request.getParameter("zipCode");
 

--- a/src/main/java/programmers/coffee/domain/order/dto/OrderRequestDto.java
+++ b/src/main/java/programmers/coffee/domain/order/dto/OrderRequestDto.java
@@ -39,9 +39,4 @@ public class OrderRequestDto {
         return order;
     }
 
-
-
-
-
-
 }

--- a/src/main/java/programmers/coffee/domain/user/domain/CustomUserDetails.java
+++ b/src/main/java/programmers/coffee/domain/user/domain/CustomUserDetails.java
@@ -65,4 +65,8 @@ public class CustomUserDetails implements UserDetails {
 
     public Long getId() {return user.getId();}
 
+    public String getEmail() {
+        return user.getEmail();
+    }
+
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 주문 생성 시, 사용자 이름(user name)이 email 컬럼에 저장되는 버그 발생 -> 버그 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
`OrderController`
- email을 user_name으로 받아오는 문제 해결
- `String email = userDetails.getEmail();`

`CustomUserDetails`
- `public String getEmail() {
        return user.getEmail();
    }` 추가